### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ ETL Utils
 [![Health](https://landscape.io/github/17zuoye/etl_utils/master/landscape.svg?style=flat)](https://landscape.io/github/17zuoye/etl_utils/master)
 [![Download](https://img.shields.io/pypi/dm/etl_utils.svg?style=flat)](https://pypi.python.org/pypi/etl_utils)
 [![License](https://img.shields.io/pypi/l/etl_utils.svg?style=flat)](https://pypi.python.org/pypi/etl_utils)
-[![Python Versions](https://pypip.in/py_versions/etl_utils/badge.svg?style=flat)](https://pypi.python.org/pypi/etl_utils)
+[![Python Versions](https://img.shields.io/pypi/pyversions/etl_utils.svg?style=flat)](https://pypi.python.org/pypi/etl_utils)
 
 
 All API are listed in `etl_utils/__init__.py`.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20etl-utils))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `etl-utils`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.